### PR TITLE
fix compilation error when using msvc 16.5

### DIFF
--- a/ipc/ipc_commands.h
+++ b/ipc/ipc_commands.h
@@ -18,6 +18,7 @@ namespace ipc_client {
 
 class IPCError;
 
+std::unique_ptr<Command> deserialize_command(const ipc::Command* command);
 
 constexpr uint32_t INVALID_TRANSACTION = ~static_cast<uint32_t>(0);
 


### PR DESCRIPTION
I don't know why it should work but it did.